### PR TITLE
Initial commit customizing the ami lookup blueprint

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+   Copyright 2016 plus3it/cfn-look-up-ami-ids contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,91 @@
 # cfn-look-up-ami-ids
 AWS Lambda blueprint to lookup AMI IDs by AMI Name
+
+This blueprint mirrors the blueprint of the same name provide by AWS, with the
+following enhancements:
+
+- Removes the restriction on looking up only AMI IDs owned by Amazon
+- Uses a new parameter, `AmiNameSearchString`, as the match pattern
+against AMI Names. Previously, the pattern was hard-coded in the blueprint
+- Improves error logging when the pattern does not match any images
+
+## Lambda Execution Role
+
+Before creating the Lambda function, first create an IAM role with the
+following policy to use with this blueprint. For convenience, name the role
+something like `cfn-look-up-ami-ids`.
+
+```
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [ "ec2:DescribeImages" ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+## CloudFormation Example Usage
+
+Use a CloudFormation Parameter to define the pattern to match against when
+searching for the AMI by Name. In the example below, the default value of the
+parameter `AmiNameStringSearch` is set to match the naming pattern Amazon uses
+for their Windows Server 2012 R2 AMIs.
+
+```
+  "Parameters" : {
+    "AmiNameSearchString" : {
+        "Description" : "Search pattern to match against an AMI Name",
+        "Type" : "String",
+        "Default" : "Windows_Server-2012-R2_RTM-English-64Bit-Base-*"
+    }
+  }
+```
+
+Call the Lambda function using a custom CloudFormation resource. This resource
+will return with an attribute named `Id` containing the AMI ID. Use the
+function `Fn::GetAtt` to reference this attribute within the `ImageId`
+property of the instance (or launch configuration).
+
+```
+  "Resources" : {
+    "AmiIdLookup": {
+      "Type": "Custom::AmiIdLookup",
+      "Properties": {
+        "ServiceToken": {
+          "Fn::Join" : [
+            ":",
+            [
+              "arn:aws:lambda",
+              { "Ref" : "AWS::Region" },
+              { "Ref" : "AWS::AccountId" },
+              "function:cfn-look-up-ami-ids"
+            ]
+          ]
+        },
+        "Region": { "Ref" : "AWS::Region" },
+        "AmiNameSearchString": { "Ref" : "AmiNameSearchString" }
+      }
+    },
+    "MyInstance" :
+    {
+      "Type" : "AWS::EC2::Instance",
+      "Properties" : {
+        "ImageId": { "Fn::GetAtt": [ "AmiIdLookup", "Id" ] },
+        # ... elided ...
+      }
+    }
+  }
+```

--- a/cfn-look-up-ami-ids.js
+++ b/cfn-look-up-ami-ids.js
@@ -1,0 +1,107 @@
+/**
+ * A sample Lambda function that looks up the latest AMI ID for a given
+ * region and architecture. Make sure to include permissions for
+ * `ec2:DescribeImages` in your execution role!
+ *
+ * See http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/walkthrough-custom-resources-lambda-lookup-amiids.html
+ * for documentation on how to use this blueprint.
+ */
+var aws = require('aws-sdk');
+var https = require('https');
+var url = require('url');
+
+// Map instance architectures to an AMI name pattern
+var archToAMINamePattern = {
+    'PV64': 'amzn-ami-pv*.x86_64-ebs',
+    'HVM64': 'amzn-ami-hvm*.x86_64-gp2',
+    'HVMG2': 'amzn-ami-graphics-hvm-*x86_64-ebs*'
+};
+
+// Check if the image is a beta or RC image (the Lambda function won't return any of these images)
+var isBeta = function(imageName) {
+    return imageName.toLowerCase().indexOf('beta') !== -1 || imageName.toLowerCase().indexOf('.rc') !== -1;
+};
+
+// Sends a response to the pre-signed S3 URL
+var sendResponse = function(event, context, responseStatus, responseData) {
+    var responseBody = JSON.stringify({
+        Status: responseStatus,
+        Reason: "See the details in CloudWatch Log Stream: " + context.logStreamName,
+        PhysicalResourceId: context.logStreamName,
+        StackId: event.StackId,
+        RequestId: event.RequestId,
+        LogicalResourceId: event.LogicalResourceId,
+        Data: responseData
+    });
+
+    console.log('RESPONSE BODY:\n', responseBody);
+
+    var parsedUrl = url.parse(event.ResponseURL);
+    var options = {
+        hostname: parsedUrl.hostname,
+        port: 443,
+        path: parsedUrl.path,
+        method: 'PUT',
+        headers: {
+            'Content-Type': '',
+            'Content-Length': responseBody.length
+        }
+    };
+
+    var req = https.request(options, function(res) {
+        console.log('STATUS:', res.statusCode);
+        console.log('HEADERS:', JSON.stringify(res.headers));
+        context.succeed('Successfully sent stack response!');
+    });
+
+    req.on('error', function(err) {
+        console.log('sendResponse Error:\n', err);
+        context.fail(err);
+    });
+
+    req.write(responseBody);
+    req.end();
+};
+
+exports.handler = function(event, context) {
+    //console.log('Received event:', JSON.stringify(event, null, 2));
+
+    if (event.RequestType === 'Delete') {
+        sendResponse(event, context, 'SUCCESS');
+        return;
+    }
+
+    var responseStatus = 'FAILED';
+    var responseData = {};
+    var ec2 = new aws.EC2({ region: event.ResourceProperties.Region });
+    var describeImagesParams = {
+        Filters: [
+            {
+                Name: 'name',
+                Values: [archToAMINamePattern[event.ResourceProperties.Architecture]]
+            }
+        ],
+        Owners: [event.ResourceProperties.Architecture === 'HVMG2' ? '679593333241' : 'amazon']
+    };
+
+    // Get AMI IDs with the specified name pattern and owner
+    ec2.describeImages(describeImagesParams, function(err, data) {
+        if (err) {
+            responseData = { Error: 'DescribeImages call failed' };
+            console.log(responseData.Error + ":\n", err);
+        } else {
+            var images = data.Images;
+            // Sort images by name in descending order -- the names contain the AMI version formatted as YYYY.MM.Ver.
+            images.sort(function(x, y) { return y.Name.localeCompare(x.Name); });
+            for (var i = 0; i < images.length; i++) {
+                if (isBeta(images[i].Name)) {
+                    continue;
+                }
+                responseStatus = 'SUCCESS';
+                responseData.Id = images[i].ImageId;
+                break;
+            }
+        }
+        sendResponse(event, context, responseStatus, responseData);
+    });
+};


### PR DESCRIPTION
- Remove the limitation on lookin up only Amazon-owned images
- Improve the error message if no images are returned
- Accept a new event resource property, AmiNameSearchString,
  which contains the pattern to match again AMI Names
